### PR TITLE
startf and offset fix

### DIFF
--- a/markovstate.py
+++ b/markovstate.py
@@ -1,5 +1,4 @@
 import time
-import itertools
 
 import tokenise
 import markov
@@ -50,9 +49,11 @@ class MarkovState:
             prefix = prefix[self.markov.n - 1:]
 
         self.markov.reset(seed, prob, prefix, cln)
-
-        itertools.dropwhile(lambda t: not startf(t), self.markov)
-        next(itertools.islice(self.markov, offset, offset), None)
+        
+        for i in range(offset):
+            next(self.markov)
+        while not startf(next(self.markov)):
+            pass
 
         def gen(n):
             out = []


### PR DESCRIPTION
itertools functions return a new iterator rather than act on the one passed to them.
To actually effect self.markov (i.e. to offset it by the passed offset and iterate through it until startf is matched), use this instead.
